### PR TITLE
Add custom react redux rule and configuration to give lively eslint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module.exports = {
     'plugin:give-lively/base',
     'plugin:give-lively/react',
     'plugin: give-lively/jest',
+    'plugin: give-lively/custom',
   ],
   env: {
     // Your environments (which contains several predefined global variables)

--- a/configs/custom.js
+++ b/configs/custom.js
@@ -1,0 +1,26 @@
+const exempt = [
+    'frontend/SmartDonations/Legacy/**/*',
+    'frontend/providers/UserProvider.js',
+    'frontend/P2P/P2PTeams/pages/TeamPage/Donate/index.jsx',
+    'frontend/SmartDonations/StoryTemplate/StoryTemplateContainer.js',
+    'frontend/SmartDonations/DefaultTemplate/index.js',
+    'frontend/__tests__/providers/UserProvider.spec.js',
+    'frontend/__tests__/SmartDonations/**/*',
+    'frontend/__tests__/Auth/CartLogin.spec.js',
+];
+
+module.exports = {
+  plugins: ["give-lively"],
+  rules: {
+    "give-lively/enforce-no-react-redux-import": "error",
+  },
+  overrides: [
+    {
+      files: exempt,
+      rules: {
+        "give-lively/enforce-no-react-redux-import": "off",
+      },
+    },
+  ],
+};
+

--- a/configs/custom.js
+++ b/configs/custom.js
@@ -1,26 +1,7 @@
-const exempt = [
-    'frontend/SmartDonations/Legacy/**/*',
-    'frontend/providers/UserProvider.js',
-    'frontend/P2P/P2PTeams/pages/TeamPage/Donate/index.jsx',
-    'frontend/SmartDonations/StoryTemplate/StoryTemplateContainer.js',
-    'frontend/SmartDonations/DefaultTemplate/index.js',
-    'frontend/__tests__/providers/UserProvider.spec.js',
-    'frontend/__tests__/SmartDonations/**/*',
-    'frontend/__tests__/Auth/CartLogin.spec.js',
-];
-
 module.exports = {
   plugins: ["give-lively"],
   rules: {
     "give-lively/enforce-no-react-redux-import": "error",
   },
-  overrides: [
-    {
-      files: exempt,
-      rules: {
-        "give-lively/enforce-no-react-redux-import": "off",
-      },
-    },
-  ],
 };
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 const baseConfig = require("./configs/base.js");
 const reactConfig = require("./configs/react.js");
 const jestConfig = require("./configs/jest.js");
+const customConfig = require("./configs/custom.js");
+const reactReduxNoImport = require("./rules/reactReduxNoImport.js");
 
 module.exports = {
   configs: {
     base: baseConfig,
     react: reactConfig,
     jest: jestConfig,
+    custom: customConfig,
+  },
+  rules: {
+    "enforce-no-react-redux-import": reactReduxNoImport,
   },
 };

--- a/plugins/custom.js
+++ b/plugins/custom.js
@@ -1,0 +1,7 @@
+const reactReduxNoImport = require("../rules/reactReduxNoImport.js");
+
+module.exports = {
+  rules: {
+    "enforce-no-react-redux-import": reactReduxNoImport,
+  },
+};

--- a/rules/reactReduxNoImport.js
+++ b/rules/reactReduxNoImport.js
@@ -1,0 +1,25 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce that `react-redux` is not imported.",
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value.includes("react-redux")) {
+          context.report({
+            node,
+            message: "Cannot import react-redux in this file.",
+            fix(fixer) {
+              return fixer.remove(node);
+            },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Jira issue: DEV-7735

This PR adds a new rule to prevent react-redux from being used except in the exempted files. 

Tested this locally by
- Running `yarn link` in this repo
- Switching to the charity-api repo and running `yarn link eslint-plugin-give-lively`
- Importing `react-redux` to [some file name]
- Running `yarn eslint [some file name]` outputted `error  Cannot import react-redux in this file  give-lively/enforce-no-react-redux-import`
- Running `yarn eslint [some file name] --fix` removed that import statement.