### PR TITLE
adds 0 and 1 to ignored values for magic numbers rule

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -58,6 +58,7 @@ module.exports = {
   "no-magic-numbers": [
     "warn",
     {
+      ignore: [0, 1],
       ignoreArrayIndexes: true,
       ignoreDefaultValues: true,
     },


### PR DESCRIPTION
## Overview
As an engineering team, we recently agreed that because the values `0` and `1` are inherently meaningful numbers within programming, we want to relax our `no-magic-numbers` eslint rule and ignore these values when linting our code. 

Ticket: https://give-lively.atlassian.net/browse/DEV-8957