### PR TITLE
Add custom rule to disallow NaN

### DIFF
--- a/configs/custom.js
+++ b/configs/custom.js
@@ -1,6 +1,7 @@
 module.exports = {
   plugins: ["give-lively"],
   rules: {
+    "give-lively/enforce-no-nan": "error",
     "give-lively/enforce-no-react-redux-import": "error",
   },
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const reactConfig = require("./configs/react.js");
 const jestConfig = require("./configs/jest.js");
 const customConfig = require("./configs/custom.js");
 const reactReduxNoImport = require("./rules/reactReduxNoImport.js");
+const noNan = require("./rules/noNan.js");
 
 module.exports = {
   configs: {
@@ -12,6 +13,7 @@ module.exports = {
     custom: customConfig,
   },
   rules: {
+    "enforce-no-nan": noNan,
     "enforce-no-react-redux-import": reactReduxNoImport,
   },
 };

--- a/plugins/custom.js
+++ b/plugins/custom.js
@@ -1,7 +1,9 @@
 const reactReduxNoImport = require("../rules/reactReduxNoImport.js");
+const noNan = require("../rules/noNan.js");
 
 module.exports = {
   rules: {
+    "enforce-no-nan": noNan,
     "enforce-no-react-redux-import": reactReduxNoImport,
   },
 };

--- a/rules/noNan.js
+++ b/rules/noNan.js
@@ -1,0 +1,22 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce that `NaN` is not explicitly used.",
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === "NaN") {
+          context.report({
+            node,
+            message: "Cannot explicitly use `NaN`.",
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Jira issue: DEV-9415

This PR adds a new rule to prevent NaN from explicitly being used.

Tested this locally by:
- Running `yarn link` in this repo
- Switching to the charity-api repo and running `yarn link eslint-plugin-give-lively`
- Adding `const x = NaN` to [some file name]
- Running yarn eslint [some file name] outputted `error    Cannot explicitly use NaN`
